### PR TITLE
issue #3: Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: android
+
+jdk:
+  - oraclejdk8
+
+android:
+  components:
+    - platform-tools-26.0.2
+    - tools
+    - build-tools-26.0.2
+    - android-25
+
+    # Additional components
+    # - extra-google-google_play_services
+    # - extra-google-m2repository
+    # - extra-android-m2repository
+    # - addon-google_apis-google-19
+
+    # Specify at least one system image,
+    # if you need to run emulator(s) during your tests
+    # - sys-img-armeabi-v7a-android-22
+    # - sys-img-armeabi-v7a-android-17
+

--- a/MRZReader/build.gradle
+++ b/MRZReader/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.mercuriete.mrz.reader"
@@ -15,6 +15,13 @@ android {
             minifyEnabled true
             proguardFiles 'proguard.cfg'
         }
+    }
+    lintOptions {
+        //we need to figure out why bounce castle is using javax
+        //because android lint complaint invalid package
+        disable 'InvalidPackage'
+        textReport true
+        textOutput 'stdout'
     }
 }
 

--- a/MRZReader/proguard.cfg
+++ b/MRZReader/proguard.cfg
@@ -76,3 +76,4 @@
 
 -dontnote org.apache.**
 -dontnote android.net.**
+-dontwarn org.bouncycastle.**

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# android-mrz-reader
+# android-mrz-reader [![Build Status](https://travis-ci.org/mercuriete/android-mrz-reader.svg?branch=master)](https://travis-ci.org/mercuriete/android-mrz-reader)
 MRZ camera reader

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 


### PR DESCRIPTION
1) upgrade build tools version
2) upgrade android gradle to 2.3.3
3) create travis yml
4) add travis badge on README.md
5) fix proguard issue when using jmrtd and bouncycastle
6) disable InvalidPackage in android lint because bouncycastle uses javax.*